### PR TITLE
Removing the need to have a TLD in the test runner URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
 	
 	config.recurse = validator.toBoolean(config.recurse);
 	
-	if (!validator.isURL(config.runner)) {
+	if (!validator.isURL(config.runner, {require_tld: false})) {
 		errors.push("--runner is required and must be a URL");
 	}
 	


### PR DESCRIPTION
Not sure if this is something that you'd want in the main release, but it is very useful to us.

Most of our development boxes don't have a TLD in the URL, for instance we use http://cfserver/. Because of the URL validation check in testbox-runner, we can't use such URL's to run our tests. This code simply removes the need for a URL to have a TLD in it.

Just reject the pull request if it's not something you'd like :)
