### PR TITLE
Better output with errors only flag

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -42,26 +42,27 @@
 	};
 	
 	var outputSuite = function(suite, config) {
-
-		if ( config.errorsOnly && ! suite.TOTALERROR && ! suite.TOTALFAIL ) {
+		if ( config.errorsOnly && ! suite.SUITESTATS.length &&
+			! suite.TOTALERROR && ! suite.TOTALFAIL ) {
 			return;
 		}
 	
-		console.log("SUITE: " + chalk.cyan(suite.NAME + ":"));
-		
-		var table = new Table({
-			head: ['Test Name', 'Time', 'Status', 'Message'],
-			style: {
-				head: [ "blue" ]
-			}
-		});
-		
-		suite.SPECSTATS.forEach(function(spec){
-			outputSpec(spec, table, config);
-		});
-		
-		console.log(table.toString());
-		console.log();
+		if ( suite.SPECSTATS.length ) {
+			var table = new Table({
+				head: ['Test Name', 'Time', 'Status', 'Message'],
+				style: {
+					head: [ "blue" ]
+				}
+			});
+
+			suite.SPECSTATS.forEach(function(spec){
+				outputSpec(spec, table, config);
+			});
+
+			console.log("SUITE: " + chalk.cyan(suite.NAME + ":"));
+			console.log(table.toString());
+			console.log();
+		}
 		
 		suite.SUITESTATS.forEach(function(nestedSuite) {
 			outputSuite(nestedSuite, config);


### PR DESCRIPTION
Sometimes failures and errors wouldn't display if the suite had no tests itself (or all passing tests) and it was a nested suite failure.