### PR TITLE
Changing all UPPERCASE variables to camelCase in lib/reporter.js

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -9,16 +9,16 @@
 	
 	var outputSpec = function(spec, table, config){
 
-		if ( config.errorsOnly && spec.STATUS === "Passed" ) {
+		if ( config.errorsOnly && spec.status === "Passed" ) {
 			return;
 		}
 		
-		var time = spec.TOTALDURATION.toString() + "ms";
-		var name = spec.NAME;
+		var time = spec.totalDuration.toString() + "ms";
+		var name = spec.name;
 		var status = "";
 		var message = "";
 		
-		switch(spec.STATUS) {
+		switch(spec.status) {
 			
 			case "Passed":
 				status = chalk.green("Passed");
@@ -27,12 +27,12 @@
 				
 			case "Failed":
 				status = chalk.yellow("Failed");
-				message = spec.FAILMESSAGE;
+				message = spec.failMessage;
 				break;
 				
 			case "Error":
 				status = chalk.red("Error");
-				message = spec.ERROR.Message;
+				message = spec.error.Message;
 				break;
 
 		}
@@ -42,12 +42,12 @@
 	};
 	
 	var outputSuite = function(suite, config) {
-		if ( config.errorsOnly && ! suite.SUITESTATS.length &&
-			! suite.TOTALERROR && ! suite.TOTALFAIL ) {
+		if ( config.errorsOnly && ! suite.suiteStats.length &&
+			! suite.totalError && ! suite.totalFail ) {
 			return;
 		}
 	
-		if ( suite.SPECSTATS.length ) {
+		if ( suite.specStats.length ) {
 			var table = new Table({
 				head: ['Test Name', 'Time', 'Status', 'Message'],
 				style: {
@@ -55,16 +55,16 @@
 				}
 			});
 
-			suite.SPECSTATS.forEach(function(spec){
+			suite.specStats.forEach(function(spec){
 				outputSpec(spec, table, config);
 			});
 
-			console.log("SUITE: " + chalk.cyan(suite.NAME + ":"));
+			console.log("SUITE: " + chalk.cyan(suite.name + ":"));
 			console.log(table.toString());
 			console.log();
 		}
 		
-		suite.SUITESTATS.forEach(function(nestedSuite) {
+		suite.suiteStats.forEach(function(nestedSuite) {
 			outputSuite(nestedSuite, config);
 		});
 		
@@ -72,13 +72,13 @@
 	
 	var outputBundle = function(bundle, config) {
 	
-		if ( config.errorsOnly && ! bundle.TOTALFAIL && ! bundle.TOTALERROR ) {
+		if ( config.errorsOnly && ! bundle.totalFail && ! bundle.totalError ) {
 			return;
 		};
 		
-		console.log(chalk.magenta("BUNDLE: " + bundle.NAME + ":"));
+		console.log(chalk.magenta("BUNDLE: " + bundle.name + ":"));
 
-		if ( bundle.GLOBALEXCEPTION ) {
+		if ( bundle.globalException ) {
 			var table = new Table({
 				head: ['Test Name', 'Status', 'Message'],
 				style: {
@@ -87,21 +87,20 @@
 			});
 			var name = "Global Exception";
 			var status = chalk.red("Error");
-			var message = bundle.GLOBALEXCEPTION.Message;
+			var message = bundle.globalException.Message;
 			table.push([ name, status, message ]);
-			console.log(table.toString());
+			console.log(table.toString());		
 		}
-		
-		bundle.SUITESTATS.forEach(function(suite) {
+
+		bundle.suiteStats.forEach(function(suite) {
 			outputSuite(suite, config);
 		});
-
 	};
 
 	var outputSummary = function(results, config) {
 		var stats = results.bundleStats.reduce(function(stats, bundle) {
-			if (bundle.TOTALERROR > 0) { stats[2].amount++; }
-			else if (bundle.TOTALFAIL > 0) { stats[1].amount++; }
+			if (bundle.totalError > 0) { stats[2].amount++; }
+			else if (bundle.totalFail > 0) { stats[1].amount++; }
 			else { stats[0].amount++; }
 			return stats;
 		}, [


### PR DESCRIPTION
On a linux environment, javascript is case sensitive (https://www.safaribooksonline.com/library/view/javascript-the-definitive/0596000480/ch02s02.html)

Currently the code before reporter.js declares multiple variables using camelCase, while reporter.js refers to them as UPPERCASE global variables.
(https://github.com/search?utf8=✓&q=org%3AColdBox+specStats&type=Code)

On a npm version 6.1.0 this fails with all the declared variables as undefined.